### PR TITLE
Use Browserify standalone option

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "dev": "budo demo/demo.js:bundle.js --live -d demo",
-    "dist": "browserify index.js -o dist/simple-dropzone.js && uglifyjs dist/simple-dropzone.js --mangle > dist/simple-dropzone.min.js",
+    "dist": "browserify --standalone SimpleDropzone index.js -o dist/simple-dropzone.js && uglifyjs dist/simple-dropzone.js --mangle > dist/simple-dropzone.min.js",
     "version": "npm run dist && git add -A dist",
     "postversion": "git push && git push --tags && npm publish"
   },


### PR DESCRIPTION
I tried using `simple-dropzone.min.js` in a simple example without any build process, i.e. 
```
<script src="../node_modules/simple-dropzone/dist/simple-dropzone.min.js">
<script>
   const dropzone = new SimpleDropzone(..., ...);
</script>
```
but `SimpleDropzone` was not defined after loading it.
Using the `standalone` option fixes that.