### PR TITLE
Small improvements in handling of ZIP archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,6 @@ Destroys the instance and unbinds all events.
 
 | Event | Properties | Description |
 |---|---|---|
-| `drop` | `files : Map<string, File>` | New files added, from either drag-and-drop or selection. |
+| `drop` | `files : Map<string, File>, archive?: File` | New files added, from either drag-and-drop or selection. `archive` is provided if the files were extracted from a ZIP archive. |
 | `dropstart` |  — | Selection is in progress. Decompressing ZIP archives may take several seconds. |
 | `droperror` | `message : string` | Selection has failed. |

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -2,15 +2,18 @@ const SimpleDropzone = require('../');
 
 const dropEl = document.querySelector('.dropzone');
 const inputEl = document.querySelector('.input');
+const textEl = document.querySelector('.text');
 const listEl = document.querySelector('.list');
 
 const dropzone = new SimpleDropzone(dropEl, inputEl);
 
-dropzone.on('drop', ({files}) => {
+dropzone.on('drop', ({files, archive}) => {
   files = Array.from( files );
   listEl.innerHTML = files
     .map(([filename, file]) => `<li>${filename} : ${file.size} bytes</li>`)
     .join('');
+  if (archive)
+    textEl.innerHTML = `Extracted from ${archive.name} : ${archive.size} bytes`;
 });
 
 dropzone.on('droperror', ({message}) => {

--- a/demo/index.html
+++ b/demo/index.html
@@ -15,7 +15,7 @@ html, body {
   max-width: 600px;
   margin: 0 auto;
 }
-.list {
+.list, .text {
   text-align: left;
 }
   </style>
@@ -26,6 +26,7 @@ html, body {
     <span class="label">Drag in or select some files.</span>
     <input type="file" multiple class="input">
   </div>
+  <div class="text"></div>
   <ul class="list"></ul>
   <script src="bundle.js"></script>
 </body>

--- a/index.js
+++ b/index.js
@@ -115,8 +115,19 @@ class SimpleDropzone {
    * @param  {Event} e
    */
   _onSelect (e) {
+
+    this._emit('dropstart');
+
     // HTML file inputs do not seem to support folders, so assume this is a flat file list.
     const files = [].slice.call(this.inputEl.files);
+    // Automatically decompress a zip archive if it is the only file given
+    if (files.length === 1) {
+      const file = files[0];
+      if (file.type === 'application/zip' || file.name.match(/\.zip$/)) {
+        this._loadZip(file);
+        return;
+      }
+    }
     const fileMap = new Map();
     files.forEach((file) => fileMap.set(file.name, file));
     this._emit('drop', {files: fileMap});
@@ -188,7 +199,7 @@ class SimpleDropzone {
     archive.importBlob(file, () => {
       traverse(archive.root);
       Promise.all(pending).then(() => {
-        this._emit('drop', {files: fileMap});
+        this._emit('drop', {files: fileMap, archive: file});
       });
     });
   }


### PR DESCRIPTION
- a ZIP archive is also extracted when using the file selection button.
- when a ZIP archive is extracted, the original file is now provided to the drop event. This is useful for instance to get its size and name.
- the dropstart event is also called when processing selected files (so a spinning element can be shown while extracting).
