### PR TITLE
Full path fix for webkit directory, also fixes duplicate file names.

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ class SimpleDropzone {
     }
 
     const fileMap = new Map();
-    files.forEach((file) => fileMap.set(file.name, file));
+    files.forEach((file) => fileMap.set(file.webkitRelativePath || file.name, file));
     this._emit('drop', {files: fileMap});
   }
 


### PR DESCRIPTION
Map keys are different if we drop a folder or select directory by clicking the choose file button(with `directory` or `webkitDirectory` option.  When dropping the key is relative path but in choose file there is no relative path in the key, but is set as webkitRelativePath in the file object. This should be consistent.
So, if we load a folder like:
```
folder/
   a/
       1.txt
   b/
       1.txt
```
It works with dropping on the selector, but while manually selecting the top directory, we only get one file(since the name is same)